### PR TITLE
Better documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,5 +33,5 @@ specifying where they show up. This example uses the (**deprecated**)
       mount-point /temp_folder
       container-class Products.TemporaryFolder.TemporaryContainer
   </zodb_db>
-  
-  For details on session configuration, see `the Zope book on session management <https://zope.readthedocs.io/en/latest/zopebook/Sessions.html>`_.
+
+For details on session configuration, see `the Zope book on session management <https://zope.readthedocs.io/en/latest/zopebook/Sessions.html>`_.

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Usage example
 You can mount additional storages into the ZODB as seen by the Zope client 
 by adding ``zodb_db`` configurations in your Zope configuration file and
 specifying where they show up. This example uses the
-ZODB `DB.MappingStorage.MappingStorage
+ZODB `MappingStorage
 <https://zodb-docs.readthedocs.io/en/latest/reference/storages.html#mappingstorage>`_
 to mount a temporary folder at ``/temp_folder``::
 
@@ -35,4 +35,5 @@ to mount a temporary folder at ``/temp_folder``::
       container-class Products.TemporaryFolder.TemporaryContainer
   </zodb_db>
 
-For details on session configuration, see `the Zope book on session management <https://zope.readthedocs.io/en/latest/zopebook/Sessions.html>`_.
+For details on session configuration, see `the Zope book chapter on session
+management <https://zope.readthedocs.io/en/latest/zopebook/Sessions.html>`_.

--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,11 @@ specifying where they show up. This example uses the (**deprecated**)
 ``/temp_folder``::
 
   <zodb_db temporary>
-      <temporarystorage>
+      <mappingstorage>
         name Temporary database
-      </temporarystorage>
+      </mappingstorage>
       mount-point /temp_folder
       container-class Products.TemporaryFolder.TemporaryContainer
   </zodb_db>
+  
+  For details on session configuration, see `the Zope book on session management <https://zope.readthedocs.io/en/latest/zopebook/Sessions.html>`_.

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,9 @@ Usage example
 You can mount additional storages into the ZODB as seen by the Zope client 
 by adding ``zodb_db`` configurations in your Zope configuration file and
 specifying where they show up. This example uses the
-ZODB `DB.MappingStorage.MappingStorage <https://zodb-docs.readthedocs.io/en/latest/reference/storages.html#mappingstorage>`_ to mount a temporary folder at
-``/temp_folder``::
+ZODB `DB.MappingStorage.MappingStorage
+<https://zodb-docs.readthedocs.io/en/latest/reference/storages.html#mappingstorage>`_
+to mount a temporary folder at ``/temp_folder``::
 
   <zodb_db temporary>
       <mappingstorage>

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ Usage example
 -------------
 You can mount additional storages into the ZODB as seen by the Zope client 
 by adding ``zodb_db`` configurations in your Zope configuration file and
-specifying where they show up. This example uses the (**deprecated**)
-``Products.TemporaryFolder`` product to mount a temporary folder at
+specifying where they show up. This example uses the
+ZODB `DB.MappingStorage.MappingStorage <https://zodb-docs.readthedocs.io/en/latest/reference/storages.html#mappingstorage>`_ to mount a temporary folder at
 ``/temp_folder``::
 
   <zodb_db temporary>


### PR DESCRIPTION
As tempstorage is deprecated and development installs are better off with mappingstorage instead, I think this would be a better default to show. Also link to zope book directly.